### PR TITLE
Improve warranty card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,8 +44,8 @@
       }
 
       .logo-wrapper img {
-        max-height: 44px;
-        max-width: 118px;
+        max-height: 54px;
+        max-width: 136px;
         width: auto;
         height: auto;
         object-fit: contain;
@@ -70,7 +70,7 @@
       .details {
         position: absolute;
         top: 50%;
-        left: 2.4rem;
+        left: 4.6rem;
         right: 2.4rem;
         transform: translateY(-50%);
         display: grid;
@@ -131,7 +131,7 @@
         }
 
         .logo-wrapper img {
-          max-height: 38px;
+          max-height: 44px;
         }
 
         .serial-number {
@@ -139,7 +139,7 @@
         }
 
         .details {
-          left: 1.8rem;
+          left: 3.6rem;
           right: 1.2rem;
         }
 


### PR DESCRIPTION
## Summary
- expand the logo constraints so brand marks render slightly larger on each card
- increase spacing between the vertical serial number and the details block to avoid overlap on all viewports

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7812456c08320b3b1c2bb2996e7f8