### PR TITLE
Adjust serial number placement for mobile layout

### DIFF
--- a/InvoiceLink.html
+++ b/InvoiceLink.html
@@ -136,7 +136,7 @@
         }
 
         .serial-number {
-          left: 1rem;
+          left: 0.75rem;
         }
 
         .details {
@@ -166,7 +166,7 @@
 
       @media (max-width: 340px) {
         .serial-number {
-          left: 0.75rem;
+          left: 0.5rem;
           font-size: 0.85rem;
           letter-spacing: 0.12em;
         }


### PR DESCRIPTION
## Summary
- shift the serial number further left on small screens to better align with the card layout

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d7883deb5c832098100db980a56782