### PR TITLE
Tighten mobile spacing for details

### DIFF
--- a/InvoiceLink.html
+++ b/InvoiceLink.html
@@ -143,6 +143,8 @@
           left: clamp(2.6rem, 7vw, 3.4rem);
           right: clamp(0.5rem, 5vw, 1.1rem);
           font-size: clamp(0.82rem, 0.7rem + 0.6vw, 0.95rem);
+          line-height: 1.28;
+          gap: 0.34rem;
         }
       }
 
@@ -154,8 +156,9 @@
         .details {
           left: 2.7rem;
           right: 0.55rem;
-          gap: 0.36rem;
+          gap: 0.3rem;
           font-size: clamp(0.82rem, 0.74rem + 0.4vw, 0.92rem);
+          line-height: 1.24;
         }
 
         .details p {
@@ -175,6 +178,8 @@
           left: 2.6rem;
           right: 0.55rem;
           font-size: clamp(0.78rem, 0.72rem + 0.4vw, 0.88rem);
+          gap: 0.26rem;
+          line-height: 1.2;
         }
 
         .card-footer {


### PR DESCRIPTION
## Summary
- reduce the spacing and line heights for card details on narrow screens
- ensure warranty card content fits more comfortably on small mobile devices

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7947c38788320a711d613f43f9d06